### PR TITLE
Feature: Add `store_materialization_results` to exemplar branch

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -29,6 +29,11 @@ vars:
   vars:
     'dbt_date:time_zone': 'America/New_York'
 
+
+# Store run results from each run within the data warehouse.
+on-run-end: "{{ store_materialization_results(results, 'dbt_materializations') }}"
+
+
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models
 models:

--- a/macros/macro.yml
+++ b/macros/macro.yml
@@ -18,3 +18,16 @@ macros:
       - name: column
         type: STRING
         description: name of the column being tested
+
+  - name: store_materialization_results
+    description: >
+      Parse dbt's result object for model materializations, and store the
+      results for the run within the data warehouse.
+    arguments:
+      - name: results
+        type: ResultsOject
+        description: The internal dbt macro Result object.
+      - name: table_name
+        type: STRING
+        description: >
+          The name of the table in which to store materialization results.

--- a/macros/store_materialization_results.sql
+++ b/macros/store_materialization_results.sql
@@ -1,0 +1,64 @@
+{% macro store_materialization_results(results, table_name) %}
+
+  {%- set central_tbl -%}
+    {{ target.schema }}.{{ table_name }}
+  {%- endset -%}
+
+  {%- set materialization_results = [] -%}
+  {%- for result in results if result.node.resource_type == 'model' -%}
+    {%- do materialization_results.append(result) -%}
+  {%- endfor -%}
+
+  {# if no models were materialized, do nothing! #}
+  {% if materialization_results | length == 0 -%}
+    {{ return('select 1') }}
+  {%- endif -%}
+
+  {{ log("Centralizing materialization data in " + central_tbl, info = true) if execute }}
+
+  {#
+		Check if the target table exists. If it does, then insert into it. Otherwise, create it.
+	#}
+  {% set central_table_query %} {{ dbt_utils.get_tables_by_pattern_sql(target.schema | upper,  table_name ) }} {% endset %}
+
+  {% if execute %}
+    {% set central_table_exists = run_query(central_table_query) %}
+  {% endif %}
+
+  {% if central_table_exists%}
+    insert into {{ central_tbl }} (
+  {% else %}
+    create table {{ central_tbl }} as (
+  {% endif %}
+
+	{# For each result in the run result set, process and store the result. #}
+  {% for result in materialization_results %}
+
+    {# Remap the timing list into a dictionary of values #}
+    {% set timing = {} %}
+    {% for timing_record in result.timing%}
+      {% do timing.update({ timing_record['name']: {
+          'started_at': timing_record['started_at'],
+          'completed_at': timing_record['completed_at']
+        } }) %}
+    {% endfor %}
+
+		{# Generate a row for each result, which maps to one row per model. #}
+    select
+      {{ dbt_utils.surrogate_key( ["'" ~ invocation_id ~ "'" , "'" ~ result.node.unique_id ~ "'" ] ) }} as materialization_id,
+      '{{ result.node.unique_id }}'::text as node_unique_id,
+      '{{ invocation_id }}'::text as invocation_id,
+      '{{ result.node.name }}'::text as model,
+      '{{ result.status }}'::text as status,
+      to_variant(parse_json('{{ tojson(result.node.config.meta) }}')) as meta,
+      '{{ timing["execute"]["started_at"] }}'::timestamptz as execution_started_at,
+      '{{ timing["execute"]["completed_at"] }}'::timestamptz as execution_completed_at,
+      '{{ result.execution_time }}'::float as execution_time_seconds,
+      current_timestamp as recorded_at
+
+    {{ "union all" if not loop.last }}
+
+  {% endfor %}
+
+  );
+{% endmacro %}


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
* "Update: dbt version 0.14.0"
-->

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

This pull request adds a new `store_materialzation_results` macro. This macro stores information from each dbt run for the models materialized. This includes the unique_id, the invocation_id, timestamps and durations, and the metadata stored on the model.

In a future update, this data will be modeled into a mart and an aggregation for improved visibility into each department's data warehouse usage.

## Screenshots:
<!---
Include a screenshot of the relevant section of the updated DAG. You can access
your version of the DAG by running `dbt docs generate && dbt docs serve`.
-->

## Validation of models:
<!---
Include any output that confirms that the models do what is expected. This might
be a link to an in-development dashboard in your BI tool, or a query that
compares an existing model with a new one.
-->

**Example Output**

| MATERIALIZATION_ID               | NODE_UNIQUE_ID                                           | INVOCATION_ID                        | MODEL                   | STATUS  | META                                                                                                             | EXECUTION_STARTED_AT          | EXECUTION_COMPLETED_AT        | EXECUTION_TIME_SECONDS | RECORDED_AT                   |
|----------------------------------|----------------------------------------------------------|--------------------------------------|-------------------------|---------|------------------------------------------------------------------------------------------------------------------|-------------------------------|-------------------------------|------------------------|-------------------------------|
| ffb94212c2be761a3d401862066f2e86 | model.coalesce_2022_dag_workshop.stg_tpch_line_items     | 6dcf42a4-b78d-4947-8f97-f7c450bd79a9 | stg_tpch_line_items     | success | {    "maturity": "high",    "owner": {      "department": "Analytics",      "email": "alice@jaffle.shop"    }  } | 2022-09-12 16:58:48.032 -0700 | 2022-09-12 16:58:49.274 -0700 | 1.545207024            | 2022-09-12 09:59:09.222 -0700 |
| 48051bdbb5d6b91365f50f08fbae0905 | model.coalesce_2022_dag_workshop.stg_tpch_nations        | 6dcf42a4-b78d-4947-8f97-f7c450bd79a9 | stg_tpch_nations        | success | {    "maturity": "high",    "owner": {      "department": "Analytics",      "email": "alice@jaffle.shop"    }  } | 2022-09-12 16:58:48.054 -0700 | 2022-09-12 16:58:49.272 -0700 | 1.54542923             | 2022-09-12 09:59:09.222 -0700 |
| a18f9f8377e48f77df4cc2f41f1818af | model.coalesce_2022_dag_workshop.stg_tpch_customers      | 6dcf42a4-b78d-4947-8f97-f7c450bd79a9 | stg_tpch_customers      | success | {    "maturity": "high",    "owner": {      "department": "Analytics",      "email": "alice@jaffle.shop"    }  } | 2022-09-12 16:58:48.051 -0700 | 2022-09-12 16:58:49.275 -0700 | 1.556507826            | 2022-09-12 09:59:09.222 -0700 |
| b883755d387e6d964c92253067302389 | model.coalesce_2022_dag_workshop.all_days                | 6dcf42a4-b78d-4947-8f97-f7c450bd79a9 | all_days                | success | {}                                                                                                               | 2022-09-12 16:58:49.015 -0700 | 2022-09-12 16:58:49.309 -0700 | 1.557951212            | 2022-09-12 09:59:09.222 -0700 |
| d94a72dec39c57a0e4705fb23d7ccc7f | model.coalesce_2022_dag_workshop.stg_tpch_orders         | 6dcf42a4-b78d-4947-8f97-f7c450bd79a9 | stg_tpch_orders         | success | {    "maturity": "high",    "owner": {      "department": "Analytics",      "email": "alice@jaffle.shop"    }  } | 2022-09-12 16:58:49.554 -0700 | 2022-09-12 16:58:50.793 -0700 | 1.584038258            | 2022-09-12 09:59:09.222 -0700 |
| 15a05c460701bf9b74d1cade40aea07d | model.coalesce_2022_dag_workshop.stg_tpch_regions        | 6dcf42a4-b78d-4947-8f97-f7c450bd79a9 | stg_tpch_regions        | success | {    "maturity": "high",    "owner": {      "department": "Analytics",      "email": "alice@jaffle.shop"    }  } | 2022-09-12 16:58:49.566 -0700 | 2022-09-12 16:58:50.884 -0700 | 1.670555115            | 2022-09-12 09:59:09.222 -0700 |
| 3a75b88c17b7f4b3717425b61dca0da5 | model.coalesce_2022_dag_workshop.stg_tpch_part_suppliers | 6dcf42a4-b78d-4947-8f97-f7c450bd79a9 | stg_tpch_part_suppliers | success | {    "maturity": "high",    "owner": {      "department": "Analytics",      "email": "alice@jaffle.shop"    }  } | 2022-09-12 16:58:49.560 -0700 | 2022-09-12 16:58:51.020 -0700 | 1.717414856            | 2022-09-12 09:59:09.222 -0700 |
| f318ef5f0c07228efd24852445a13d0c | model.coalesce_2022_dag_workshop.stg_tpch_parts          | 6dcf42a4-b78d-4947-8f97-f7c450bd79a9 | stg_tpch_parts          | success | {    "maturity": "high",    "owner": {      "department": "Analytics",      "email": "alice@jaffle.shop"    }  } | 2022-09-12 16:58:49.569 -0700 | 2022-09-12 16:58:51.022 -0700 | 1.721351862            | 2022-09-12 09:59:09.222 -0700 |
| 14e121eaebefc2f29c675c248c9b6e17 | model.coalesce_2022_dag_workshop.stg_tpch_suppliers      | 6dcf42a4-b78d-4947-8f97-f7c450bd79a9 | stg_tpch_suppliers      | success | {    "maturity": "high",    "owner": {      "department": "Analytics",      "email": "alice@jaffle.shop"    }  } | 2022-09-12 16:58:51.143 -0700 | 2022-09-12 16:58:52.056 -0700 | 1.156082869            | 2022-09-12 09:59:09.222 -0700 |


## Changes to existing models:
<!---
Include this section if you are changing any existing models. Link any related
pull requests on your BI tool, or instructions for merge (e.g. whether old
models should be dropped after merge, or whether a full-refresh run is required)
-->

None!

## Checklist:
<!---
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.
Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.
-->
- [x] My pull request represents one logical piece of work.
- [x] My commits are related to the pull request and look clean.
- [x] My SQL follows the [Fishtown Analytics style guide](https://github.com/fishtown-analytics/corp/blob/master/dbt_coding_conventions.md).
- [x] I have materialized my models appropriately.
- [x] I have added appropriate tests and documentation to any new models.
- [x] I have updated the README file.