### PR TITLE
Feat: Add macro for generating fake results

### DIFF
--- a/macros/fake_results.sql
+++ b/macros/fake_results.sql
@@ -1,0 +1,20 @@
+{% macro fake_results(count = 10) %}
+    {% set results = [ ] %}
+    {% for node in graph.nodes.values()  %}
+        {% if node.resource_type in ('model', 'test') and results|length < count %}
+            {% do results.append({
+                'status': 'success',
+                'execution_time': 1.1,
+                'thread_id': 'Thread-1',
+                'timing': [],
+                'adapter_response': {
+                    'rows_affected': 1,
+                },
+                'message': 'Faked Result',
+                'node': node
+            }) %}
+        {% endif %}
+
+    {% endfor %}
+    {{ return(results) }}
+{% endmacro %}

--- a/macros/macro.yml
+++ b/macros/macro.yml
@@ -19,6 +19,13 @@ macros:
         type: STRING
         description: name of the column being tested
 
+  - name: fake_results
+    description: Return a list of mock results for demonstrative purposes.
+    arguments:
+      - name: count
+        type: INT
+        description: The number of fake results to return. Set to 10 by default.
+
   - name: store_materialization_results
     description: >
       Parse dbt's result object for model materializations, and store the


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
* "Update: dbt version 0.14.0"
-->

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

For this workship, we believe that there is value in being more exemplary in our demonstration of dbt Jinja's internal objects. With this in mind, I've created a macro that will use the internal graph object to generate a fake results object.


## Checklist:
<!---
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.
Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.
-->
- [x] My pull request represents one logical piece of work.
- [x] My commits are related to the pull request and look clean.
- [x] My SQL follows the [dbt Labs Analytics style guide](https://github.com/fishtown-analytics/corp/blob/master/dbt_coding_conventions.md).
- [x] I have added appropriate tests and documentation to any new models.
